### PR TITLE
feat(efs): Add uid and gid parameters for EFS storage classes

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -74,6 +74,8 @@ variable "efs_storage_classes" {
       provisioningMode = optional(string, "efs-ap")
       gidRangeStart    = optional(string, null)
       gidRangeEnd      = optional(string, null)
+      uid              = optional(string, null)
+      gid              = optional(string, null)
       # Support for cross-account EFS mounts
       # See https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/master/examples/kubernetes/cross_account_mount
       # and for gritty details on secrets: https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html


### PR DESCRIPTION
## What

Add `uid` and `gid` optional parameters to the EFS storage class configuration.

## Why

Workloads running as non-root users need write access to EFS volumes. The EFS CSI driver supports setting owner uid/gid on access points, but this component doesn't expose those parameters.

Reference: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#storage-class-parameters-for-dynamic-provisioning

## Changes

- Added `uid` and `gid` optional string parameters to `efs_storage_classes.parameters`
- No changes to main.tf (existing passthrough logic handles new params)

## Testing

```yaml
efs_storage_classes:
  efs-ray:
    parameters:
      uid: "1000"
      gid: "1000"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EFS storage configuration now supports optional UID and GID parameters to specify ownership for dynamically provisioned access points, enabling deployment of non-root workloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->